### PR TITLE
Plugins

### DIFF
--- a/src/commands/PluginCommand.js
+++ b/src/commands/PluginCommand.js
@@ -1,4 +1,3 @@
-import fs from "fs";
 import glob from "glob";
 import path from "path";
 

--- a/src/commands/PluginCommand.js
+++ b/src/commands/PluginCommand.js
@@ -1,0 +1,75 @@
+import fs from "fs";
+import glob from "glob";
+import path from "path";
+
+import Command from "../Command";
+import PackageUtilities from "../PackageUtilities";
+
+export function handler(argv) {
+  return new PluginCommand([argv.script, ...argv.args], argv).run();
+}
+
+export const command = "plugin <script> [args..]";
+
+export const describe = "Run a plugin in every package.";
+
+export const builder = {
+  "sort": {
+    describe: "Sort packages topologically (all dependencies before dependents)",
+    type: "boolean",
+    default: false,
+  },
+};
+
+export default class PluginCommand extends Command {
+  get requiresGit() {
+    return false;
+  }
+
+  initialize(callback) {
+    this.script = this.input[0];
+    this.args = this.input.slice(1);
+
+    if (!this.script) {
+      callback(new Error("You must specify which plugin to run."));
+      return;
+    }
+
+    const { plugins = ["plugins"] } = this.repository.lernaJson;
+    plugins.forEach((pattern) => {
+      glob.sync(path.join(process.cwd(), pattern)).forEach((pluginDir) => {
+        const pluginFile = path.join(pluginDir, this.script) + ".js";
+        if (fs.existsSync(pluginFile)) {
+          this.plugin = require(pluginFile);
+        }
+      });
+    });
+
+    if (!this.plugin) {
+      callback(new Error(`Unable to find plugin ${this.script}.`));
+      return;
+    }
+
+    this.batchedPackages = this.toposort
+      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages)
+      : [this.filteredPackages];
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    const tracker = this.logger.newItem(this.script);
+    tracker.addWork(this.filteredPackages.length);
+
+    PackageUtilities.runParallelBatches(this.batchedPackages, (pkg) => (done) => {
+      this.plugin(this.script, pkg, tracker, (err) => {
+        tracker.silly(pkg.name);
+        tracker.completeWork(1);
+        done(err);
+      });
+    }, this.concurrency, (err) => {
+      tracker.finish();
+      callback(err);
+    });
+  }
+}

--- a/src/commands/PluginCommand.js
+++ b/src/commands/PluginCommand.js
@@ -62,10 +62,14 @@ export default class PluginCommand extends Command {
     tracker.addWork(this.filteredPackages.length);
 
     PackageUtilities.runParallelBatches(this.batchedPackages, (pkg) => (done) => {
-      this.plugin(this.script, pkg, tracker, (err) => {
+      this.plugin((err) => {
         tracker.silly(pkg.name);
         tracker.completeWork(1);
         done(err);
+      }, {
+        log: tracker,
+        name: this.script,
+        pkg,
       });
     }, this.concurrency, (err) => {
       tracker.finish();

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
+import PluginCommand from "./commands/PluginCommand";
 
 export default {
   BootstrapCommand,
@@ -19,5 +20,6 @@ export default {
   InitCommand,
   RunCommand,
   ExecCommand,
-  LsCommand
+  LsCommand,
+  PluginCommand,
 };


### PR DESCRIPTION
A simple plugin system via a new command: `lerna plugin [name]`.

## Description

This new feature enables a build script author to write scripts that get executed for each package, but within Lerna. This is different that using `lerna exec` because it's run as part of Lerna, so you get the same information as if you were writing a built-in lerna command, just with a simpler API.

## Motivation and Context

Currently if you want to run a script in the context of a package, or multiple packages, you have to either:

1. Define an NPM script in each package's `package.json`
2. Wrap `lerna exec` in a script and point it at another script

Number 1 gets cumbersome because you have to do it for every `package.json`. This means that you need to either put your whole script in the one line, or define a separate script that is called to from it. No matter what you do here, you have to keep every package.json up to date.

Number 2 requires you make two scripts: one to wrap `lerna exec`, and another to point `lerna exec` to. You lose valuable information in the process such as package information, logging (scoped tracker from `logger.newItem(this.script)`) and the command instance itself (maybe this is too much info).

For example, the command `lerna plugin test --concurrency 2 --rand 1000` could be implemented by the following code. Note that you can play with the `concurrency` and `rand` to see how it affects completion time.

```js
// ./plugins/test/index.js

const yargs = require('yargs').options({
  rand: {
    default: 100,
    type: 'number',
  },
});

module.exports = (done, { pkg, log }) => {
  const rand = Math.random() * Math.random() * yargs.argv.rand;
  setTimeout(() => {
    log.info(pkg.name);
    done();
  }, rand);
};
```

### Automatic plugin resolution / modularising build tool plugins

Another benefit of having a standard way to add functionality that isn't specific to Lerna's core is being able to ship packages that hook straight into Lerna. For example, suppose I wrote a build package called `lerna-plugin-storybook` that allows you to run and build static React Storybooks. The most you'd need to do to integrate it would be to add it in your `lerna.json`:

```js
{
  // This is currently the default.
  plugins: [
    './plugins',
    './node_modules/lerna-plugin-*'
  ]
}
```

However, if those are the defaults, all you'd need to do is simply install / write plugins based on these conventions and things just work (tm).

### CLI options

CLI options aren't parsed for you (not sure if this is a good idea yet). If you need to do this simply parse cli options with Yargs or whatever. This is fairly trivial to do and to automate would require one less line of code because you have to define your options anyways.

Maybe this is naive and we should think more about it.

### Lerna to plugin version coupling

Since the interface of a plugin is only a function that accepts arguments, the API surface area will have less conflicts than if it were a class that required certain fields be set. I'd like to try and keep the implementation as simple as possible.

## How Has This Been Tested?

It hasn't yet; this is just a PoC.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
